### PR TITLE
Add support for java.util.Optional

### DIFF
--- a/src/com/amazon/mqa/datagen/rof/typed/DefaultOptionalFactory.java
+++ b/src/com/amazon/mqa/datagen/rof/typed/DefaultOptionalFactory.java
@@ -1,0 +1,28 @@
+package com.amazon.mqa.datagen.rof.typed;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.lang.reflect.Type;
+import java.util.Optional;
+
+/**
+ * The default implementation of {@link OptionalFactory}.
+ */
+final class DefaultOptionalFactory implements OptionalFactory {
+
+    /** Creates objects from type. */
+    private final TypedObjectFactory typedObjectFactory;
+
+    public DefaultOptionalFactory (final TypedObjectFactory typedObjectFactory) {
+        checkNotNull(typedObjectFactory, "typedObjectFactory cannot be null");
+
+        this.typedObjectFactory = typedObjectFactory;
+    }
+
+    @Override
+    public Optional create(final Type optionalType) {
+        checkNotNull(optionalType, "optionalType cannot be null");
+
+        return Optional.of(typedObjectFactory.create(optionalType));
+    }
+}

--- a/src/com/amazon/mqa/datagen/rof/typed/DefaultTypedObjectFactory.java
+++ b/src/com/amazon/mqa/datagen/rof/typed/DefaultTypedObjectFactory.java
@@ -7,6 +7,7 @@ import com.amazon.mqa.datagen.rof.ObjectFactory;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * Default implementation of {@link TypedObjectFactory}.
@@ -22,6 +23,9 @@ public final class DefaultTypedObjectFactory implements TypedObjectFactory {
     /** Creates map object. */
     private final MapFactory mapFactory;
 
+    /** Creates optional objects. */
+    private final OptionalFactory optionalFactory;
+
     /**
      * Instantiates a new {@link DefaultTypedObjectFactory}.
      *
@@ -34,6 +38,7 @@ public final class DefaultTypedObjectFactory implements TypedObjectFactory {
         this.objectFactory = objectFactory;
         this.collectionFactory =  DefaultCollectionFactory.create(this);
         this.mapFactory = DefaultMapFactory.create(this);
+        this.optionalFactory = new DefaultOptionalFactory(this);
     }
 
     /**
@@ -46,10 +51,12 @@ public final class DefaultTypedObjectFactory implements TypedObjectFactory {
      */
     DefaultTypedObjectFactory(final ObjectFactory objectFactory,
                               final CollectionFactory collectionFactory,
-                              final MapFactory mapFactory) {
+                              final MapFactory mapFactory,
+                              final OptionalFactory optionalFactory) {
         this.objectFactory = checkNotNull(objectFactory, "objectFactory cannot be null");
         this.collectionFactory = checkNotNull(collectionFactory, "collectionFactory cannot be null");
         this.mapFactory = checkNotNull(mapFactory, "objectFactory cannot be null");
+        this.optionalFactory = checkNotNull(optionalFactory, "optionalFactory cannot be null");
     }
 
     @Override
@@ -68,6 +75,8 @@ public final class DefaultTypedObjectFactory implements TypedObjectFactory {
             //TODO: add robust way to check if type can be handled
             if (rawType.equals(Map.class)) {
                 return mapFactory.create(actualTypeArguments[0], actualTypeArguments[1]);
+            } else if (rawType.equals(Optional.class)) {
+                return optionalFactory.create(actualTypeArguments[0]);
             } else {
                 return collectionFactory.create(rawType, actualTypeArguments[0]);
             }

--- a/src/com/amazon/mqa/datagen/rof/typed/OptionalFactory.java
+++ b/src/com/amazon/mqa/datagen/rof/typed/OptionalFactory.java
@@ -1,0 +1,18 @@
+package com.amazon.mqa.datagen.rof.typed;
+
+import java.lang.reflect.Type;
+import java.util.Optional;
+
+/**
+ * Creates {@link Optional} objects.
+ */
+interface OptionalFactory {
+
+    /**
+     * Creates an {@link Optional} from a type.
+     *
+     * @param optionalType the type to create an {@link Optional} for.
+     * @return the optional.
+     */
+    Optional create(Type optionalType);
+}

--- a/tst/com/amazon/mqa/datagen/TestClassA.java
+++ b/tst/com/amazon/mqa/datagen/TestClassA.java
@@ -4,6 +4,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -38,6 +39,9 @@ public final class TestClassA {
     /** a string field. */
     private final String stringField;
 
+    /** an optional field. */
+    private final Optional<Integer> optionalField;
+
     /** a list field. */
     private final List<List<Integer>> list;
 
@@ -67,8 +71,9 @@ public final class TestClassA {
     //CHECKSTYLE:SUPPRESS:Param Count
     TestClassA(final boolean booleanField, final byte byteField, final char charField,
              final double doubleField, final float floatField, final int intField, final long longField,
-             final short shortField, final String stringField, final List<List<Integer>> list,
-             final Set<Double> doubles, final Map<Set<Integer>, List<String>> mapField) {
+             final short shortField, final String stringField, final Optional<Integer> optionalField,
+             final List<List<Integer>> list, final Set<Double> doubles,
+             final Map<Set<Integer>, List<String>> mapField) {
         this.booleanField = booleanField;
         this.byteField = byteField;
         this.charField = charField;
@@ -78,6 +83,7 @@ public final class TestClassA {
         this.longField = longField;
         this.shortField = shortField;
         this.stringField = checkNotNull(stringField, "stringField cannot be null");
+        this.optionalField = checkNotNull(optionalField, "optionalField cannot be null");
         this.list = checkNotNull(list, "list cannot be null");
         this.doubleSet = checkNotNull(doubles, "doubles cannot be null");
         this.mapField = checkNotNull(mapField, "mapField cannot be null");
@@ -164,6 +170,15 @@ public final class TestClassA {
      */
     public String getStringField() {
         return stringField;
+    }
+
+    /**
+     * Gets optional field.
+     *
+     * @return the field.
+     */
+    public Optional<Integer> getOptionalField() {
+        return optionalField;
     }
 
     /**

--- a/tst/com/amazon/mqa/datagen/rof/typed/DefaultOptionalFactoryTest.java
+++ b/tst/com/amazon/mqa/datagen/rof/typed/DefaultOptionalFactoryTest.java
@@ -1,0 +1,66 @@
+package com.amazon.mqa.datagen.rof.typed;
+
+import static org.easymock.EasyMock.expect;
+import static org.testng.Assert.assertEquals;
+
+import com.amazon.mqa.datagen.supplier.RandomIntegerSupplier;
+import com.amazon.mtqa.testutil.MockObjectContainer;
+import com.google.common.base.Supplier;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+/**
+ * Unit test for {@link DefaultOptionalFactory}.
+ */
+public final class DefaultOptionalFactoryTest {
+
+    /** Creates random integers. */
+    private final Supplier<Integer> integerFactory = new RandomIntegerSupplier();
+
+    /** Contains mocks. */
+    private MockObjectContainer mocks;
+
+    /** Mock typed object factory. */
+    private TypedObjectFactory mockTypedObjectFactory;
+
+    /** Class under test. */
+    private OptionalFactory factory;
+
+    /**
+     * Required test set up.
+     */
+    @SuppressWarnings("unchecked")
+    @BeforeMethod
+    public void setUp() {
+        mocks = new MockObjectContainer();
+
+        mockTypedObjectFactory = mocks.createMock("mockTypedObjectFactory", TypedObjectFactory.class);
+
+        factory = new DefaultOptionalFactory(mockTypedObjectFactory);
+    }
+
+    /**
+     * Tests creating Optional.
+     *
+     * @throws Exception for any failure.
+     */
+    @Test
+    public void testCreateOptional() throws Exception {
+
+        // set up
+        final Class<Integer> clazz = Integer.class;
+        final Integer expected = integerFactory.get();
+
+        expect(mockTypedObjectFactory.create(clazz)).andReturn(expected);
+
+        mocks.replayAll();
+
+        // exercise
+        final Optional actual = factory.create(clazz);
+
+        // verify
+        assertEquals(actual, Optional.of(expected), "wrong optional");
+    }
+}

--- a/tst/com/amazon/mqa/datagen/rof/typed/DefaultTypedObjectFactoryTest.java
+++ b/tst/com/amazon/mqa/datagen/rof/typed/DefaultTypedObjectFactoryTest.java
@@ -18,6 +18,7 @@ import java.lang.reflect.TypeVariable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * Unit test for {@link DefaultTypedObjectFactory}.
@@ -39,6 +40,9 @@ public final class DefaultTypedObjectFactoryTest {
     /** Mock map factory. */
     private MapFactory mockMapFactory;
 
+    /** Mock optional factory. */
+    private OptionalFactory mockOptionalFactory;
+
     /** Object under test. */
     private TypedObjectFactory factory;
 
@@ -50,8 +54,10 @@ public final class DefaultTypedObjectFactoryTest {
         mockObjectFactory = mocks.createMock("mockObjectFactory", ObjectFactory.class);
         mockCollectionFactory = mocks.createMock("mockCollectionFactory", CollectionFactory.class);
         mockMapFactory = mocks.createMock("mockMapFactory", MapFactory.class);
+        mockOptionalFactory = mocks.createMock("mockOptionalFactory", OptionalFactory.class);
 
-        factory = new DefaultTypedObjectFactory(mockObjectFactory, mockCollectionFactory, mockMapFactory);
+        factory = new DefaultTypedObjectFactory(mockObjectFactory, mockCollectionFactory,
+                mockMapFactory, mockOptionalFactory);
     }
 
     /**
@@ -117,6 +123,31 @@ public final class DefaultTypedObjectFactoryTest {
 
         // verify
         assertEquals(actual, expected, "wrong map");
+        mocks.verifyAll();
+    }
+
+    /**
+     * Tests creating optional.
+     *
+     * @throws Exception for any failure
+     */
+    @Test
+    public void testCreateOptional() throws Exception {
+        // set up
+        final Optional<Integer> expected = Optional.of(1);
+        final Object container = new Object() {
+            Optional<Integer> optional;
+        };
+
+        expect(mockOptionalFactory.create(Integer.class)).andReturn(expected);
+
+        mocks.replayAll();
+
+        // exercise
+        final Object actual = factory.create(container.getClass().getDeclaredField("optional").getGenericType());
+
+        // verify
+        assertEquals(actual, expected, "wrong optional");
         mocks.verifyAll();
     }
 


### PR DESCRIPTION
Adds support for classes with Optional fields that are parametrized with types that ObjectFactory can create.

Does not support Optional fields with generic type parameters, such as:

``` java
class SomeClass<T> {
    Optional<T> someField;
}
```
