### PR TITLE
Add checkstyle rules to build

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,6 +18,14 @@ libraryDependencies ++= Seq(
   "org.easymock" % "easymock" % "3.4" % "test"
 )
 
+// Checkstyle settings
+checkstyleConfigLocation := CheckstyleConfigLocation.File("configuration/checkstyle/checkstyle-8.8-config.xml")
+
+(checkstyle in Test) := (checkstyle in Test).triggeredBy(compile in Test).value
+(checkstyle in Compile) := (checkstyle in Compile).triggeredBy(compile in Compile).value
+
+checkstyleSeverityLevel := Some(CheckstyleSeverityLevel.Warning)
+
 // TestNG settings
 enablePlugins(TestNGPlugin)
 

--- a/configuration/checkstyle/checkstyle-8.8-config.xml
+++ b/configuration/checkstyle/checkstyle-8.8-config.xml
@@ -1,0 +1,140 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.3//EN" "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+
+<module name="Checker">
+    <property name="severity" value="error"/>
+    <module name="TreeWalker">
+        <module name="JavadocType"/>
+        <module name="JavadocVariable"/>
+        <module name="JavadocStyle"/>
+        <module name="JavadocMethod"/>
+        <module name="ConstantName"/>
+        <module name="LocalFinalVariableName"/>
+        <module name="LocalVariableName"/>
+        <module name="MemberName"/>
+        <module name="MethodName"/>
+        <module name="PackageName"/>
+        <module name="ParameterName"/>
+        <module name="StaticVariableName"/>
+        <module name="TypeName"/>
+        <module name="AvoidStarImport"/>
+        <module name="IllegalImport"/>
+        <module name="RedundantImport"/>
+        <module name="UnusedImports"/>
+        <module name="LineLength">
+            <property name="ignorePattern" value="(^ *\** *\$Id\:)|(^import )"/>
+            <property name="max" value="115"/>
+        </module>
+        <module name="MethodLength">
+            <property name="max" value="50"/>
+            <property name="countEmpty" value="false"/>
+            <property name="tokens" value="METHOD_DEF"/>
+        </module>
+        <module name="ParameterNumber">
+            <property name="max" value="4"/>
+        </module>
+        <module name="EmptyForIteratorPad"/>
+        <module name="MethodParamPad"/>
+        <module name="NoWhitespaceAfter">
+            <property name="tokens" value="BNOT,DEC,DOT,INC,LNOT,UNARY_MINUS,UNARY_PLUS"/>
+        </module>
+        <module name="NoWhitespaceBefore"/>
+        <module name="OperatorWrap"/>
+        <module name="ParenPad"/>
+        <module name="TypecastParenPad"/>
+        <module name="WhitespaceAfter"/>
+        <module name="WhitespaceAround">
+            <property name="tokens" value="ASSIGN,BAND,BAND_ASSIGN,BOR,BOR_ASSIGN,BSR,BSR_ASSIGN,BXOR,BXOR_ASSIGN,COLON,DIV,DIV_ASSIGN,EQUAL,GE,GT,LAND,LCURLY,LE,LITERAL_ASSERT,LITERAL_CATCH,LITERAL_DO,LITERAL_ELSE,LITERAL_FINALLY,LITERAL_FOR,LITERAL_IF,LITERAL_RETURN,LITERAL_SYNCHRONIZED,LITERAL_TRY,LITERAL_WHILE,LOR,LT,MINUS,MINUS_ASSIGN,MOD,MOD_ASSIGN,NOT_EQUAL,PLUS,PLUS_ASSIGN,QUESTION,RCURLY,SL,SLIST,SL_ASSIGN,SR,SR_ASSIGN,STAR,STAR_ASSIGN,LITERAL_ASSERT,TYPE_EXTENSION_AND"/>
+        </module>
+        <module name="ModifierOrder"/>
+        <module name="RedundantModifier"/>
+        <module name="EmptyBlock">
+            <property name="tokens" value="LITERAL_DO,LITERAL_ELSE,LITERAL_FINALLY,LITERAL_FOR,LITERAL_TRY,LITERAL_WHILE,STATIC_INIT"/>
+        </module>
+        <module name="LeftCurly"/>
+        <module name="NeedBraces"/>
+        <module name="RightCurly"/>
+        <module name="AvoidInlineConditionals">
+            <property name="severity" value="ignore"/>
+        </module>
+        <module name="EmptyStatement"/>
+        <module name="EqualsHashCode"/>
+        <module name="HiddenField">
+            <property name="tokens" value="VARIABLE_DEF"/>
+        </module>
+        <module name="IllegalInstantiation"/>
+        <module name="InnerAssignment">
+            <property name="severity" value="ignore"/>
+        </module>
+        <module name="MagicNumber"/>
+        <module name="MissingSwitchDefault"/>
+        <module name="SimplifyBooleanExpression">
+            <property name="severity" value="ignore"/>
+        </module>
+        <module name="SimplifyBooleanReturn"/>
+        <module name="FinalClass"/>
+        <module name="HideUtilityClassConstructor"/>
+        <module name="InterfaceIsType"/>
+        <module name="VisibilityModifier"/>
+        <module name="ArrayTypeStyle"/>
+        <module name="FinalParameters"/>
+        <module name="TodoComment">
+            <property name="severity" value="ignore"/>
+        </module>
+        <module name="UpperEll"/>
+        <module name="AnonInnerLength">
+            <property name="severity" value="ignore"/>
+            <property name="max" value="100"/>
+        </module>
+        <module name="AvoidNestedBlocks">
+            <property name="severity" value="ignore"/>
+        </module>
+        <module name="CovariantEquals"/>
+        <module name="DefaultComesLast"/>
+        <module name="FallThrough"/>
+        <module name="FinalLocalVariable"/>
+        <module name="IllegalCatch"/>
+        <module name="IllegalThrows"/>
+        <module name="IllegalType">
+            <property name="tokens" value="METHOD_DEF,PARAMETER_DEF,VARIABLE_DEF"/>
+            <property name="legalAbstractClassNames" value="AbstractStep"/>
+        </module>
+        <module name="ModifiedControlVariable"/>
+        <module name="MultipleStringLiterals">
+            <property name="severity" value="ignore"/>
+        </module>
+        <module name="NestedTryDepth"/>
+        <module name="NestedIfDepth">
+            <property name="max" value="2"/>
+        </module>
+        <module name="StringLiteralEquality"/>
+        <module name="DesignForExtension" />
+        <module name="MutableException"/>
+        <module name="MethodLength">
+            <property name="max" value="20"/>
+            <property name="tokens" value="CTOR_DEF"/>
+        </module>
+        <module name="Regexp">
+            <property name="format" value="^import org\.testng\.v6"/>
+            <property name="message" value="use Google collections instead"/>
+            <property name="illegalPattern" value="true"/>
+        </module>
+        <module name="MissingOverride"/>
+        <module name="MissingDeprecated"/>
+        <module name="NoClone"/>
+        <module name="SuppressionCommentFilter">
+            <property name="offCommentFormat" value="CHECKSTYLE\:SUPPRESS\:([\w\|]+)"/>
+            <property name="onCommentFormat" value="CHECKSTYLE\:UNSUPPRESS\:([\w\|]+)$"/>
+            <property name="checkFormat" value="$1"/>
+        </module>
+        <module name="SuppressWithNearbyCommentFilter"/>
+    </module>
+    <module name="FileLength">
+        <property name="max" value="1000"/>
+    </module>
+    <module name="FileTabCharacter"/>
+    <module name="NewlineAtEndOfFile">
+        <property name="severity" value="ignore"/>
+    </module>
+    <module name="Translation"/>
+</module>

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,4 +2,7 @@ logLevel := Level.Warn
 
 addSbtPlugin("de.johoop" % "sbt-testng-plugin" % "3.1.1")
 
+addSbtPlugin("com.etsy" % "sbt-checkstyle-plugin" % "3.1.1")
+dependencyOverrides += "com.puppycrawl.tools" % "checkstyle" % "8.8"
+
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.3")

--- a/src/com/amazon/mqa/datagen/rof/typed/DefaultCollectionFactory.java
+++ b/src/com/amazon/mqa/datagen/rof/typed/DefaultCollectionFactory.java
@@ -48,7 +48,7 @@ final class DefaultCollectionFactory implements CollectionFactory {
      * @param provider provides concretes collection instance.
      * @throws NullPointerException if any argument is <code>null</code>.
      */
-    public DefaultCollectionFactory(final TypedObjectFactory typedObjectFactory,
+    DefaultCollectionFactory(final TypedObjectFactory typedObjectFactory,
                                     final Supplier<Integer> sizeSupplier,
                                     final CollectionInstanceProvider provider) {
         this.typedObjectFactory = checkNotNull(typedObjectFactory, "typeFactory cannot be null");

--- a/src/com/amazon/mqa/datagen/rof/typed/DefaultMapFactory.java
+++ b/src/com/amazon/mqa/datagen/rof/typed/DefaultMapFactory.java
@@ -43,7 +43,7 @@ final class DefaultMapFactory implements MapFactory {
      * @param sizeSupplier supplies array size.
      * @throws NullPointerException if any argument is <code>null</code>.
      */
-    public DefaultMapFactory(final TypedObjectFactory typedObjectFactory, final Supplier<Integer> sizeSupplier) {
+    DefaultMapFactory(final TypedObjectFactory typedObjectFactory, final Supplier<Integer> sizeSupplier) {
         this.typedObjectFactory = checkNotNull(typedObjectFactory, "typeFactory cannot be null");
         this.sizeSupplier = checkNotNull(sizeSupplier, "sizeSupplier cannot be null");
     }

--- a/src/com/amazon/mqa/datagen/rof/typed/DefaultOptionalFactory.java
+++ b/src/com/amazon/mqa/datagen/rof/typed/DefaultOptionalFactory.java
@@ -18,7 +18,7 @@ final class DefaultOptionalFactory implements OptionalFactory {
      *
      * @param typedObjectFactory the object factory to use
      */
-    public DefaultOptionalFactory(final TypedObjectFactory typedObjectFactory) {
+    DefaultOptionalFactory(final TypedObjectFactory typedObjectFactory) {
         checkNotNull(typedObjectFactory, "typedObjectFactory cannot be null");
 
         this.typedObjectFactory = typedObjectFactory;

--- a/src/com/amazon/mqa/datagen/rof/typed/DefaultTypedObjectFactory.java
+++ b/src/com/amazon/mqa/datagen/rof/typed/DefaultTypedObjectFactory.java
@@ -61,6 +61,7 @@ public final class DefaultTypedObjectFactory implements TypedObjectFactory {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public Object create(final Type type) {
         checkNotNull(type, "type cannot be null");
 

--- a/tst/com/amazon/mqa/datagen/rof/EnumFactoryTest.java
+++ b/tst/com/amazon/mqa/datagen/rof/EnumFactoryTest.java
@@ -16,12 +16,12 @@ public final class EnumFactoryTest {
     /**
      * Test empty enum.
      */
-    private static enum EmptyEnum { }
+    private enum EmptyEnum { }
 
     /**
      * Test enum.
      */
-    private static enum TestEnum { ENUM1, ENUM2 }
+    private enum TestEnum { ENUM1, ENUM2 }
 
     /**
      * Tests creating empty enum.

--- a/tst/com/amazon/mqa/datagen/rof/PojoFactoryFunctionalTest.java
+++ b/tst/com/amazon/mqa/datagen/rof/PojoFactoryFunctionalTest.java
@@ -32,7 +32,7 @@ public final class PojoFactoryFunctionalTest {
          * @param number int field.
          * @throws NullPointerException if any argument is <code>null</code>.
          */
-        public ClassOnlyHasPrimitive(final String str, final int number) {
+        ClassOnlyHasPrimitive(final String str, final int number) {
             checkNotNull(str, "str cannot be null");
 
             this.str = str;
@@ -53,7 +53,7 @@ public final class PojoFactoryFunctionalTest {
          * @param doubles double list.
          * @throws NullPointerException if any argument is <code>null</code>.
          */
-        public ClassWithPrimitiveCollection(final List<Double> doubles) {
+        ClassWithPrimitiveCollection(final List<Double> doubles) {
             this.doubles = checkNotNull(doubles, "doubles cannot be null");
         }
     }

--- a/tst/com/amazon/mqa/datagen/rof/spy/DefaultClassSpyTest.java
+++ b/tst/com/amazon/mqa/datagen/rof/spy/DefaultClassSpyTest.java
@@ -29,7 +29,7 @@ public final class DefaultClassSpyTest {
         /**
          * Instantiates a new {@link ClassWithNoArgumentConstructor}.
          */
-        public ClassWithNoArgumentConstructor() { }
+        ClassWithNoArgumentConstructor() { }
 
         /**
          * Test method.
@@ -52,7 +52,7 @@ public final class DefaultClassSpyTest {
          *
          * @param num dummy field.
          */
-        public ClassWithTwoConstructor(final int num) { }
+        ClassWithTwoConstructor(final int num) { }
 
         /**
          * Instantiates a new {@link ClassWithTwoConstructor}.
@@ -60,7 +60,7 @@ public final class DefaultClassSpyTest {
          * @param num1 dummy field 1.
          * @param num2 dummy field 2.
          */
-        public ClassWithTwoConstructor(final int num1, final int num2) { }
+        ClassWithTwoConstructor(final int num1, final int num2) { }
     }
 
     /** Instance under test. */
@@ -77,9 +77,9 @@ public final class DefaultClassSpyTest {
                 {ClassWithoutConstructor.class,
                     "private com.amazon.mqa.datagen.rof.spy.DefaultClassSpyTest$ClassWithoutConstructor()"},
                 {ClassWithNoArgumentConstructor.class,
-                    "public com.amazon.mqa.datagen.rof.spy.DefaultClassSpyTest$ClassWithNoArgumentConstructor()"},
+                    "com.amazon.mqa.datagen.rof.spy.DefaultClassSpyTest$ClassWithNoArgumentConstructor()"},
                 {ClassWithTwoConstructor.class,
-                    "public com.amazon.mqa.datagen.rof.spy.DefaultClassSpyTest$ClassWithTwoConstructor(int)"}
+                    "com.amazon.mqa.datagen.rof.spy.DefaultClassSpyTest$ClassWithTwoConstructor(int)"}
         };
     }
 


### PR DESCRIPTION
Add checkstyle rules (#27)

Ported old MerchantTech checkstyle rules to Checkstyle 8.8 from 5.6

Removed a few redundant modifiers to be compliant (the [RedundantModifier](http://checkstyle.sourceforge.net/config_modifier.html#RedundantModifier) check has evolved with the language spec since the good ol' marketplace days)

Suppress expected compilation warnings in DefaultTypedObjectFactory